### PR TITLE
Remove useless fields

### DIFF
--- a/_template/_conf/schema.xml
+++ b/_template/_conf/schema.xml
@@ -26,12 +26,8 @@
   <field name="gender" type="lowercase" indexed="true" stored="false" omitNorms="true" />
   <field name="ipi" type="lowercase_mult" indexed="true" stored="false" multiValued="true" />
   <field name="isni" type="lowercase_mult" indexed="true" stored="false" multiValued="true" />
-  <!-- mbid needs to be indexed because it's the unique key -->
+  <!-- mbid needs to be stored because it's the unique key -->
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
-  <!-- copies name exactly as it appears in the database, so it may be diverted into analysis for
-       "artist" and "artistaccent"-->
-  <field name="name" type="string" indexed="true" stored="false" />
-  <field name="names" type="text_multi" indexed="true" stored="false" multiValued="true" />
   <field name="sortname" type="text" indexed="true" stored="false" required="true" />
   <field name="tag" type="text_multi" indexed="true" stored="false" multiValued="true" />
   <field name="type" type="lowercase" indexed="true" stored="false" omitNorms="true" />
@@ -40,13 +36,8 @@
   <!-- If you remove this field, you must _also_ disable the update log in solrconfig.xml
      or Solr won't start. _version_ and update log are required for SolrCloud. -->
   <field name="_version_" type="long" indexed="true" stored="true" />
-  <copyField source="name" dest="artist" />
-  <copyField source="name" dest="artistaccent" />
+  <copyField source="artist" dest="artistaccent" />
   <copyField source="mbid" dest="arid" />
-  <copyField source="alias" dest="names" />
-  <copyField source="artist" dest="names" />
   <!-- field to use to determine and enforce document uniqueness. -->
   <uniqueKey>mbid</uniqueKey>
-  <!-- field for the QueryParser to use when an explicit fieldname is absent -->
-  <defaultSearchField>names</defaultSearchField>
 </schema>

--- a/event/conf/schema.xml
+++ b/event/conf/schema.xml
@@ -19,7 +19,6 @@
   <field name="event" type="text" indexed="true" stored="false" />
   <!-- mbid needs to be indexed because it's the unique key -->
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
-  <field name="name" type="string" indexed="true" stored="false" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
   <field name="pid" type="mbid" indexed="true" stored="false" multiValued="true" />
   <field name="place" type="text" indexed="true" stored="false" multiValued="true" />
@@ -31,8 +30,7 @@
      or Solr won't start. _version_ and update log are required for SolrCloud. -->
   <field name="_version_" type="long" indexed="true" stored="true" />
   <copyField source="mbid" dest="eid" />
-  <copyField source="name" dest="event" />
-  <copyField source="name" dest="ngram" />
+  <copyField source="event" dest="ngram" />
   <copyField source="artist" dest="ngram" />
   <!-- field to use to determine and enforce document uniqueness. -->
   <uniqueKey>mbid</uniqueKey>

--- a/label/conf/schema.xml
+++ b/label/conf/schema.xml
@@ -20,9 +20,6 @@
   <field name="laid" type="mbid" indexed="true" stored="false" required="true" />
   <!-- mbid needs to be indexed because it's the unique key -->
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
-  <!-- copies name exactly as it appears in the database, so it may be diverted into analysis for
-       "label" and "labelaccent"-->
-  <field name="name" type="string" indexed="true" stored="false" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
   <field name="release_count" type="int" indexed="true" stored="false" />
   <field name="sortname" type="text_mult" indexed="true" stored="false" multiValued="true" />
@@ -33,10 +30,9 @@
   <!-- If you remove this field, you must _also_ disable the update log in solrconfig.xml
      or Solr won't start. _version_ and update log are required for SolrCloud. -->
   <field name="_version_" type="long" indexed="true" stored="true" />
-  <copyField source="name" dest="label" />
-  <copyField source="name" dest="labelaccent" />
+  <copyField source="label" dest="labelaccent" />
   <copyField source="mbid" dest="laid" />
-  <copyField source="name" dest="ngram" />
+  <copyField source="label" dest="ngram" />
   <copyField source="sortname" dest="ngram" />
   <!-- field to use to determine and enforce document uniqueness. -->
   <uniqueKey>mbid</uniqueKey>

--- a/recording/conf/schema.xml
+++ b/recording/conf/schema.xml
@@ -20,7 +20,6 @@
   <!-- mbid needs to be indexed because it's the unique key -->
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
   <field name="number" type="string" indexed="true" stored="false" multiValued="true" />
-  <field name="name" type="string" indexed="true" stored="false" required="true" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
   <field name="position" type="int" indexed="true" stored="false" multiValued="true" />
   <field name="primarytype" type="lowercase_mult" indexed="true" stored="false" multiValued="true" />
@@ -48,9 +47,8 @@
   <copyField source="mbid" dest="rid" />
   <copyField source="primarytype" dest="type" />
   <copyField source="secondarytype" dest="type" />
-  <copyField source="name" dest="recording" />
-  <copyField source="name" dest="recordingaccent" />
-  <copyField source="name" dest="ngram" />
+  <copyField source="recording" dest="recordingaccent" />
+  <copyField source="recording" dest="ngram" />
   <!-- field to use to determine and enforce document uniqueness. -->
   <uniqueKey>mbid</uniqueKey>
 </schema>

--- a/release-group/conf/schema.xml
+++ b/release-group/conf/schema.xml
@@ -14,7 +14,6 @@
   <field name="creditname" type="text_mult" indexed="true" stored="false" multiValued="true" />
   <!-- mbid needs to be indexed because it's the unique key -->
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
-  <field name="name" type="string" indexed="false" stored="false" />
   <field name="primarytype" type="lowercase" indexed="true" stored="false" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
   <!-- releases in this release group -->
@@ -32,11 +31,10 @@
   <field name="_store" type="storefield" indexed="false" stored="true" />
   <field name="_version_" type="long" indexed="true" stored="true" />
   <copyField source="mbid" dest="rgid" />
-  <copyField source="name" dest="releasegroup" />
-  <copyField source="name" dest="releasegroupaccent" />
+  <copyField source="releasegroup" dest="releasegroupaccent" />
   <copyField source="primarytype" dest="type" />
   <copyField source="secondarytype" dest="type" />
-  <copyField source="name" dest="ngram" />
+  <copyField source="releasegroup" dest="ngram" />
   <!-- field to use to determine and enforce document uniqueness. -->
   <uniqueKey>mbid</uniqueKey>
 </schema>

--- a/release/conf/schema.xml
+++ b/release/conf/schema.xml
@@ -26,9 +26,6 @@
   <!-- mbid needs to be indexed because it's the unique key -->
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
   <field name="mediums" type="int" indexed="true" stored="false" />
-  <!-- copies name exactly as it appears in the database, so it may be diverted into analysis for
-       "release" and "releaseaccent"-->
-  <field name="name" type="string" indexed="false" stored="false" multiValued="true" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
   <field name="primarytype" type="lowercase" indexed="true" stored="false" />
   <field name="quality" type="lowercase" indexed="true" stored="false" />
@@ -48,12 +45,11 @@
   <!-- If you remove this field, you must _also_ disable the update log in solrconfig.xml
        or Solr won't start. _version_ and update log are required for SolrCloud. -->
   <field name="_version_" type="long" indexed="true" stored="true" />
-  <copyField source="name" dest="release" />
-  <copyField source="name" dest="releaseaccent" />
+  <copyField source="release" dest="releaseaccent" />
+  <copyField source="release" dest="ngram" />
   <copyField source="mbid" dest="reid" />
   <copyField source="primarytype" dest="type" />
   <copyField source="secondarytype" dest="type" />
-  <copyField source="name" dest="ngram" />
   <!-- field to use to determine and enforce document uniqueness. -->
   <uniqueKey>mbid</uniqueKey>
 </schema>

--- a/work/conf/schema.xml
+++ b/work/conf/schema.xml
@@ -14,7 +14,6 @@
   <field name="lang" type="lowercase" indexed="true" stored="false" multiValued="true" />
   <!-- mbid needs to be indexed because it's the unique key -->
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
-  <field name="name" type="string" indexed="false" stored="false" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
   <field name="recording" type="text_mult" indexed="true" stored="false" multiValued="true" />
   <field name="recording_count" type="int" indexed="true" stored="false" />
@@ -26,8 +25,7 @@
   <field name="workaccent" type="title_keep_accents" indexed="true" stored="false" required="true" />
   <field name="_store" type="storefield" indexed="false" stored="true" />
   <field name="_version_" type="long" indexed="true" stored="true" />
-  <copyField source="name" dest="work" />
-  <copyField source="name" dest="workaccent" />
+  <copyField source="work" dest="workaccent" />
   <copyField source="mbid" dest="wid" />
   <copyField source="alias" dest="ngram" />
   <copyField source="work" dest="ngram" />


### PR DESCRIPTION
The "name" fields were added on the wrong assumption that copyfield copies fields after analysis. So in order to preserve the original data a simple "string" field called "name" was created which then copied data into other fields with various analyzers. However, this is clearly wrong, as stated in the Solr documentation, copyfield copies the values before any analyzers are run. Thus, we can safely remove these fields and make our index more efficient. Reminder: Corresponding changes in SIR also need to be made.

See https://lucene.apache.org/solr/guide/6_6/copying-fields.html