### PR TITLE
Add a new tokenizer to deal with punctuation queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ mechanism of Solr 5. It will not work with all versions of Solr 4.
 
 To run a Solr server with the cores definied in this repository, you first need
 to install
-[the MusicBrainz QueryResponseWriter](https://github.com/metabrainz/mb-solrquerywriter)
+[the MusicBrainz QueryResponseWriter](https://github.com/metabrainz/mb-solr)
 and place the resulting file called
-solrwriter-0.0.1-SNAPSHOT-jar-with-dependencies.jar into the `mbsssss/lib`
+mb-solr-0.0.1-SNAPSHOT-jar-with-dependencies.jar into the `mbsssss/lib`
 folder, which is configured as the Solr server's **sharedLib** folder.
 
 ## Running a Solr server with these cores

--- a/common/fieldtypes.xml
+++ b/common/fieldtypes.xml
@@ -18,10 +18,10 @@ Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
   <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
     <analyzer>
       <charFilter class="solr.MappingCharFilterFactory" mapping="common/mapping-MBCharEquivToChar.txt" />
-      <tokenizer class="solr.WhitespaceTokenizerFactory" />
-      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1"
-      catenateWords="0" catenateNumbers="6" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"
-      splitOnNumerics="1" stemEnglishPossessive="0" />
+      <tokenizer class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFactory" />
+      <filter class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFilterFactory"/>
+      <filter class="solr.TrimFilterFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory"
       id="[ー[:Script=Katakana:]]Katakana-Hiragana" />
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory" id="Traditional-Simplified" />
@@ -33,10 +33,10 @@ Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
   <fieldType name="text_mult" class="solr.TextField" positionIncrementGap="1">
     <analyzer>
       <charFilter class="solr.MappingCharFilterFactory" mapping="common/mapping-MBCharEquivToChar.txt" />
-      <tokenizer class="solr.WhitespaceTokenizerFactory" />
-      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1"
-      catenateWords="0" catenateNumbers="6" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"
-      splitOnNumerics="1" stemEnglishPossessive="0" />
+      <tokenizer class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFactory" />
+      <filter class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFilterFactory"/>
+      <filter class="solr.TrimFilterFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory"
       id="[ー[:Script=Katakana:]]Katakana-Hiragana" />
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory" id="Traditional-Simplified" />
@@ -47,10 +47,10 @@ Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
     <analyzer>
       <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([N|n][O|o]\.)\s+(\d+)" replacement="$1$2" />
       <charFilter class="solr.MappingCharFilterFactory" mapping="common/mapping-MBCharEquivToChar.txt" />
-      <tokenizer class="solr.WhitespaceTokenizerFactory" />
-      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1"
-      catenateWords="0" catenateNumbers="6" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"
-      splitOnNumerics="1" stemEnglishPossessive="0" />
+      <tokenizer class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFactory" />
+      <filter class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFilterFactory"/>
+      <filter class="solr.TrimFilterFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory"
       id="[ー[:Script=Katakana:]]Katakana-Hiragana" />
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory" id="Traditional-Simplified" />
@@ -61,10 +61,10 @@ Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
     <analyzer>
       <charFilter class="solr.MappingCharFilterFactory" mapping="common/mapping-MBCharEquivToChar.txt" />
       <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([N|n][O|o]\.)\s+(\d+)" replacement="$1$2" />
-      <tokenizer class="solr.WhitespaceTokenizerFactory" />
-      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1"
-      catenateWords="0" catenateNumbers="6" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"
-      splitOnNumerics="1" stemEnglishPossessive="0" />
+      <tokenizer class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFactory" />
+      <filter class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFilterFactory"/>
+      <filter class="solr.TrimFilterFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory"
       id="[ー[:Script=Katakana:]]Katakana-Hiragana" />
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory" id="Traditional-Simplified" />
@@ -75,10 +75,10 @@ Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
     <analyzer>
       <charFilter class="solr.MappingCharFilterFactory" mapping="common/mapping-MBCharEquivToChar.txt" />
       <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([N|n][O|o]\.)\s+(\d+)" replacement="$1$2" />
-      <tokenizer class="solr.WhitespaceTokenizerFactory" />
-      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1"
-      catenateWords="0" catenateNumbers="6" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"
-      splitOnNumerics="1" stemEnglishPossessive="0" />
+      <tokenizer class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFactory" />
+      <filter class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFilterFactory"/>
+      <filter class="solr.TrimFilterFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory"
       id="[ー[:Script=Katakana:]]Katakana-Hiragana" />
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory" id="Traditional-Simplified" />
@@ -88,28 +88,26 @@ Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
   <fieldType name="keep_accents" class="solr.TextField" positionIncrementGap="100">
     <analyzer>
       <charFilter class="solr.MappingCharFilterFactory" mapping="common/mapping-MBCharEquivToChar.txt" />
-      <tokenizer class="solr.WhitespaceTokenizerFactory" />
-      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1"
-      catenateWords="0" catenateNumbers="6" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"
-      splitOnNumerics="1" stemEnglishPossessive="0" />
+      <tokenizer class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFactory" />
+      <filter class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFilterFactory"/>
+      <filter class="solr.TrimFilterFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory"
       id="[ー[:Script=Katakana:]]Katakana-Hiragana" />
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory" id="Traditional-Simplified" />
-      <filter class="solr.LowerCaseFilterFactory" />
     </analyzer>
   </fieldType>
   <fieldType name="title_keep_accents" class="solr.TextField" positionIncrementGap="100">
     <analyzer>
       <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([N|n][O|o]\.)\s+(\d+)" replacement="$1$2" />
       <charFilter class="solr.MappingCharFilterFactory" mapping="common/mapping-MBCharEquivToChar.txt" />
-      <tokenizer class="solr.WhitespaceTokenizerFactory" />
-      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1"
-      catenateWords="0" catenateNumbers="6" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"
-      splitOnNumerics="1" stemEnglishPossessive="0" />
+      <tokenizer class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFactory" />
+      <filter class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFilterFactory"/>
+      <filter class="solr.TrimFilterFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory"
       id="[ー[:Script=Katakana:]]Katakana-Hiragana" />
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory" id="Traditional-Simplified" />
-      <filter class="solr.LowerCaseFilterFactory" />
     </analyzer>
   </fieldType>
   <!-- lowercases the entire field value, keeping it as a single token.  -->
@@ -130,10 +128,10 @@ Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
   <fieldType name="ngram" class="solr.TextField" positionIncrementGap="100">
     <analyzer type="query">
       <charFilter class="solr.MappingCharFilterFactory" mapping="common/mapping-MBCharEquivToChar.txt" />
-      <tokenizer class="solr.WhitespaceTokenizerFactory" />
-      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1"
-      catenateWords="0" catenateNumbers="6" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"
-      splitOnNumerics="1" stemEnglishPossessive="0" />
+      <tokenizer class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFactory" />
+      <filter class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFilterFactory"/>
+      <filter class="solr.TrimFilterFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory"
       id="[ー[:Script=Katakana:]]Katakana-Hiragana" />
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory" id="Traditional-Simplified" />
@@ -141,10 +139,10 @@ Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
     </analyzer>
     <analyzer type="index">
       <charFilter class="solr.MappingCharFilterFactory" mapping="common/mapping-MBCharEquivToChar.txt" />
-      <tokenizer class="solr.WhitespaceTokenizerFactory" />
-      <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1"
-      catenateWords="0" catenateNumbers="6" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"
-      splitOnNumerics="1" stemEnglishPossessive="0" />
+      <tokenizer class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFactory" />
+      <filter class="org.musicbrainz.search.analysis.MusicbrainzTokenizerFilterFactory"/>
+      <filter class="solr.TrimFilterFactory"/>
+      <filter class="solr.LowerCaseFilterFactory"/>
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory"
       id="[ー[:Script=Katakana:]]Katakana-Hiragana" />
       <filter class="org.apache.lucene.analysis.icu.ICUTransformFilterFactory" id="Traditional-Simplified" />


### PR DESCRIPTION
The previous analyzer pipeline, although it preserved the original token, created exponential sub queries, since it basically copied each token because of the preserveOriginal flag. This lead to Solr getting under heavy load.

Using this new tokenizer/filer, which are basically an almost replica of the old search server ones, except for the fact that the new MBSFilter replaces ALHPANUMPUNCT's non alpha chars with spaces so that trim filter can work on it instead of Word Delim Filter which has been deprecated.

This allows for us to search for purely punctuational tokens like "!!!" while still filtering something like "as!!" to "as"

Depends on https://github.com/metabrainz/mb-solr/pull/26