### PR TITLE
SOLR-95: Support ISNI (and IPI) for Artist and Label fuzzy search

### DIFF
--- a/artist/conf/request-params.xml
+++ b/artist/conf/request-params.xml
@@ -1,7 +1,7 @@
 <lst name="defaults">
   <str name="echoParams">explicit</str>
   <str name="fl">score,_store</str>
-  <str name="qf">alias^1.75 primary_alias^2 artist^2 artistaccent^2.2 comment ngram^0.5 sortname^1.85</str>
+  <str name="qf">alias^1.75 primary_alias^2 artist^2 artistaccent^2.2 comment ipi isni ngram^0.5 sortname^1.85</str>
   <str name="pf">primary_alias^2 artist^2 artistaccent^2.2 alias^1.75 sortname^1.85 comment</str>
   <str name="bf">log(sum(ref_count,150))^4</str>
 </lst>

--- a/label/conf/request-params.xml
+++ b/label/conf/request-params.xml
@@ -1,7 +1,7 @@
 <lst name="defaults">
   <str name="echoParams">explicit</str>
   <str name="fl">score,_store</str>
-  <str name="qf">alias^1.25 area^0.5 code comment country^0.75 ipi label^2 labelaccent^1.5 laid ngram sortname^1.5 type
+  <str name="qf">alias^1.25 area^0.5 code comment country^0.75 ipi isni label^2 labelaccent^1.5 laid ngram sortname^1.5 type
   tag</str>
   <str name="pf">alias area comment label^1.5 labelaccent sortname tag</str>
   <str name="bf">log(sum(release_count,1))^2</str>

--- a/label/conf/schema.xml
+++ b/label/conf/schema.xml
@@ -15,6 +15,7 @@
   <field name="end" type="date" indexed="true" stored="false" />
   <field name="ended" type="bool" indexed="true" stored="false" />
   <field name="ipi" type="string" indexed="true" stored="false" multiValued="true" />
+  <field name="isni" type="string" indexed="true" stored="false" multiValued="true" />
   <field name="label" type="text" indexed="true" stored="false" />
   <field name="labelaccent" type="keep_accents" indexed="true" stored="false" />
   <field name="laid" type="mbid" indexed="true" stored="false" required="true" />


### PR DESCRIPTION
# Summary
* This is a…
    * [x] Feature addition
* Support ISNI (and IPI) for Artist and Label fuzzy search

# Problem

* JIRA ticket: [SOLR-95](https://tickets.metabrainz.org/browse/SOLR-95)

(Note: IPI is already supported for Label fuzzy search, and is already indexed for both Artist and Label.)