### PR TITLE
Add CLI option to output search fields in list format

### DIFF
--- a/searchfields.py
+++ b/searchfields.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 import glob
+import argparse
 
 from xml.etree import ElementTree
 
@@ -19,6 +22,12 @@ COLUMN = \
 | {fieldname} ||
 """
 
+IGNORED_FIELDS = set(['mbid', 'ngram', 'ref_count'])
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-l", action="store_true", help="Display fields as a python list")
+args = parser.parse_args()
+
 schemafiles = glob.glob("[a-z]*/conf/schema.xml")
 schemafiles.sort()
 
@@ -33,8 +42,16 @@ for _file in schemafiles:
             schemaname = elem.attrib["name"].capitalize()
         elif elem.tag == "field":
             fieldname = elem.attrib["name"]
-            if not fieldname[0] == "_":
-                columns.append(COLUMN.format(fieldname=fieldname))
-    print(TABLE.format(schema=schemaname))
-    print("".join(columns))
-    print("|}")
+            if not fieldname[0] == "_" and fieldname not in IGNORED_FIELDS:
+                if args.l:
+                    columns.append(fieldname)
+                else:
+                    columns.append(COLUMN.format(fieldname=fieldname))
+    if args.l:
+        print("'%s': [" % schemaname.lower(), end="")
+        print(", ".join(["'%s'" % c for c in sorted(columns)]), end="")
+        print("]")
+    else:
+        print(TABLE.format(schema=schemaname))
+        print("".join(columns))
+        print("|}")


### PR DESCRIPTION
Can be used to generate a list f valid search fields for using in code in addition to wiki output.

Also add a list of ignored field types which are only used internally