### PR TITLE
 SOLR-95: Add 'isni' field to 'label' search index

### DIFF
--- a/common/fieldtypes.xml
+++ b/common/fieldtypes.xml
@@ -198,7 +198,7 @@ Copyright (c) 2014, 2015 Wieland Hoffmann, Jeff Weeks
   </fieldType>
   <!-- Strips leading zeroes from a string (multiple values); also insert dashes, spaces, etc. in
       the wrong place and still match -->
-  <!-- USED FOR: Artist.(isni|ipi) -->
+  <!-- USED FOR: (Artist|Label).(isni|ipi) -->
   <fieldType name="strip_leading_zeroes_concat_mult" class="solr.TextField" positionIncrementGap="1">
     <analyzer>
       <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\s]+)" replacement="" />

--- a/label/conf/schema.xml
+++ b/label/conf/schema.xml
@@ -15,6 +15,7 @@
   <field name="end" type="date" indexed="true" stored="false" />
   <field name="ended" type="bool" indexed="true" stored="false" />
   <field name="ipi" type="string" indexed="true" stored="false" multiValued="true" />
+  <field name="isni" type="string" indexed="true" stored="false" multiValued="true" />
   <field name="label" type="text" indexed="true" stored="false" />
   <field name="labelaccent" type="keep_accents" indexed="true" stored="false" />
   <field name="laid" type="mbid" indexed="true" stored="false" required="true" />

--- a/label/conf/schema.xml
+++ b/label/conf/schema.xml
@@ -14,8 +14,8 @@
   <field name="country" type="text_mult" indexed="true" stored="false" multiValued="true" />
   <field name="end" type="date" indexed="true" stored="false" />
   <field name="ended" type="bool" indexed="true" stored="false" />
-  <field name="ipi" type="string" indexed="true" stored="false" multiValued="true" />
-  <field name="isni" type="string" indexed="true" stored="false" multiValued="true" />
+  <field name="ipi" type="strip_leading_zeroes_concat_mult" indexed="true" stored="false" multiValued="true" />
+  <field name="isni" type="strip_leading_zeroes_concat_mult" indexed="true" stored="false" multiValued="true" />
   <field name="label" type="text" indexed="true" stored="false" />
   <field name="labelaccent" type="keep_accents" indexed="true" stored="false" />
   <field name="laid" type="mbid" indexed="true" stored="false" required="true" />


### PR DESCRIPTION
Complete [SOLR-95](https://tickets.metabrainz.org/browse/SOLR-95): Add support for ISNI field search for Label
----

* Add 'isni' field to 'label' search index (was missing for SOLR-95);
* Also clean both 'ipi' and 'isni' fields for 'label' using the same function as for 'artist'.