### PR TITLE
MBS-218 (schema) / MBS-384 (schema): Add `firstreleasedate` search field for recording and release group

### DIFF
--- a/recording/conf/schema.xml
+++ b/recording/conf/schema.xml
@@ -15,6 +15,7 @@
   <field name="country" type="lowercase_mult" indexed="true" stored="false" multiValued="true" omitNorms="true" />
   <field name="date" type="date" indexed="true" stored="false" />
   <field name="dur" type="long" indexed="true" stored="false" />
+  <field name="firstreleasedate" type="date" indexed="true" stored="false" />
   <field name="format" type="lowercase_mult" indexed="true" stored="false" multiValued="true" omitNorms="true" />
   <field name="isrc" type="lowercase_mult" indexed="true" stored="false" multiValued="true" omitNorms="true" />
   <!-- mbid needs to be indexed because it's the unique key -->

--- a/release-group/conf/schema.xml
+++ b/release-group/conf/schema.xml
@@ -12,6 +12,7 @@
   <field name="artistname" type="text_mult" indexed="true" stored="false" multiValued="true" />
   <field name="comment" type="text" indexed="true" stored="false" />
   <field name="creditname" type="text_mult" indexed="true" stored="false" multiValued="true" />
+  <field name="firstreleasedate" type="date" indexed="true" stored="false" />
   <!-- mbid needs to be indexed because it's the unique key -->
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
   <field name="primarytype" type="lowercase" indexed="true" stored="false" />


### PR DESCRIPTION
# Problems

Recordings and release groups cannot be searched by date.

SEARCH-218: Add first release date to the web service indexed search results for recordings
SEARCH-384: Web service : searching release-groups by date

# Solution

* Add `firstreleasedate` search field for both recordings (thanks to musicbrainz-server@v-2020-12-16 with `ACTIVE_SCHEMA_SEQUENCE` set to `26`) and release groups (available from `release_group_meta` table).

# Checklist for author

* [x] Check documentation: to be updated with the corresponding SIR update.

# Action

1. Merge related PRs to sir and mb-solr too.
2. Release both PRs at the same time.