### PR TITLE
SEARCH-590 (schema): Add `packaging` search field for release

### DIFF
--- a/release/conf/schema.xml
+++ b/release/conf/schema.xml
@@ -27,6 +27,7 @@
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
   <field name="mediums" type="int" indexed="true" stored="false" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />
+  <field name="packaging" type="strip_spaces_and_separators" indexed="true" stored="false" />
   <field name="primarytype" type="lowercase" indexed="true" stored="false" />
   <field name="quality" type="lowercase" indexed="true" stored="false" />
   <field name="reid" type="mbid" indexed="true" stored="false" />


### PR DESCRIPTION
# Problem

Releases cannot be searched by type of packaging.

SEARCH-590: Advanced release search by packaging type

# Solution

Add `packaging` to (advanced) search fields of release.
Make it insensitive to letter case, spacing, and punctuations.

# Checklist for author

* [x] Check documentation: to be updated with the corresponding SIR update.

# Action

1. Merge metabrainz/sir#102 too.
2. Release both PRs at the same time.