### PR TITLE
SEARCH-574: Make easier to type medium format

### DIFF
--- a/release/conf/schema.xml
+++ b/release/conf/schema.xml
@@ -19,7 +19,7 @@
   <field name="date" type="date" indexed="true" stored="false" multiValued="true" />
   <field name="discids" type="int" indexed="true" stored="false" />
   <field name="discidsmedium" type="int" indexed="true" stored="false" />
-  <field name="format" type="lowercase" indexed="true" stored="false" multiValued="true" />
+  <field name="format" type="strip_spaces_and_separators" indexed="true" stored="false" multiValued="true" />
   <field name="laid" type="mbid" indexed="true" stored="false" multiValued="true" />
   <field name="label" type="text_mult" indexed="true" stored="false" multiValued="true" />
   <field name="lang" type="lowercase" indexed="true" stored="false" />


### PR DESCRIPTION
# Problem

SEARCH-574: Cannot search release by medium format with special characters

Because release medium format may contain special characters or dashes, it can be uneasy to type it correctly with the same separators.

# Solution

Allow `format` search to be a bit fuzzy by ignoring letter case, spacing, and separators.

# Checklist for author

* [X] Update https://wiki.musicbrainz.org/Indexed_Search_Syntax accordingly
* [X] Update https://wiki.musicbrainz.org/MusicBrainz_API/Search accordingly
  See https://wiki.musicbrainz.org/index.php?title=MusicBrainz_API/Search/ReleaseSearch&curid=6976&diff=74997&oldid=74570

# Action

1. After search deployment, make updated WikiDocs pages visible on MusicBrainz website:
   * https://musicbrainz.org/doc/Indexed_Search_Syntax
   * https://musicbrainz.org/doc/MusicBrainz_API/Search