### PR TITLE
SEARCH-644 (schema): Drop ordering attribute from searchable fields for series

### DIFF
--- a/series/conf/schema.xml
+++ b/series/conf/schema.xml
@@ -8,7 +8,6 @@
   <similarity class="solr.SchemaSimilarityFactory" />
   <field name="alias" type="text_mult" indexed="true" stored="false" multiValued="true" />
   <field name="comment" type="text" indexed="true" stored="false" />
-  <field name="orderingattribute" type="lowercase" indexed="true" stored="false" />
   <!-- id needs to be indexed because it's the unique key -->
   <field name="mbid" type="mbid" indexed="true" stored="true" required="true" />
   <field name="ngram" type="ngram" indexed="true" stored="false" multiValued="true" />


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to Search Index Rebuilder (SIR).
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/sir/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

SEARCH-644: Remove unintented ordering attribute from series index


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This commit stops making `orderingattribute` a searchable field.

It also has to be stopped from being submitted by the indexer, see metabrainz/sir#117.

# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] No WikiDocs to be updated as this field was not documented


# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Deploy this pull request
2. Deploy metabrainz/sir#117
3. Rebuild `series` search index
