### PR TITLE
Use solr.data.home system property to allow SOLR_DATA_HOME env var to override Solr core data locations

### DIFF
--- a/common/commonSolrConfig.xml
+++ b/common/commonSolrConfig.xml
@@ -9,7 +9,7 @@
   <xi:include href="queryCache.xml" />
   <updateHandler class="solr.DirectUpdateHandler2">
     <updateLog>
-      <str name="dir">${solr.solr.home}/data/${solr.core.name:}</str>
+      <str name="dir">${solr.data.home}/${solr.core.name:}</str>
     </updateLog>
     <!-- https://cwiki.apache.org/confluence/display/solr/Near+Real+Time+Searching -->
     <xi:include href="common/autoCommit.xml" />

--- a/common/dataDir.xml
+++ b/common/dataDir.xml
@@ -1,1 +1,1 @@
-<dataDir>${solr.solr.home}/data/${solr.core.name:}</dataDir>
+<dataDir>${solr.data.home}/${solr.core.name:}</dataDir>


### PR DESCRIPTION
The Solr docs state that the `SOLR_DATA_HOME` environment variable can be used to configure the data directory for Solr cores. Unfortunately, the solr config for the mbsssss cores doesn't use the `solr.data.home` system property, which means that setting `SOLR_DATA_HOME` has no effect.

This fixes that by using `${solr.data.home}` instead of `${solr.solr.home}/data`.