### PR TITLE
SEARCH-685 (SolrCloud): Update cores’ common config after Solr 9

### DIFF
--- a/common/directoryFactory.xml
+++ b/common/directoryFactory.xml
@@ -1,2 +1,4 @@
-<!-- we could use org.apache.solr.core.RAMDirectoryFactory to store the index in RAM -->
-<directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.StandardDirectoryFactory}" />
+<!-- https://solr.apache.org/guide/solr/latest/configuration-guide/index-location-format.html#specifying-the-directoryfactory-for-your-index -->
+<directoryFactory
+    name="DirectoryFactory"
+    class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}" />

--- a/common/queryCache.xml
+++ b/common/queryCache.xml
@@ -1,4 +1,21 @@
 <query>
-  <queryResultCache class="solr.CaffeineCache" size="32768" initialSize="8192" autowarmCount="512" maxRamMB="200" />
-  <documentCache class="solr.CaffeineCache" size="32768" initialSize="8192" autowarmCount="4096" />
+  <!-- https://solr.apache.org/guide/solr/latest/configuration-guide/caches-warming.html#caches -->
+  <queryResultCache
+    class="${mb.queryResultCache.class:solr.CaffeineCache}"
+    size="${mb.queryResultCache.size:32768}"
+    initialSize="${mb.queryResultCache.initialSize:8192}"
+    autowarmCount="${mb.queryResultCache.autoWarmCount:512}"
+    maxRamMB="${mb.queryResultCache.maxRamMB:200}"
+    maxIdleTime="${mb.queryResultCache.MaxIdleTime:0}"
+    async="${mb.queryResultCache.async:true}"
+    enabled="${mb.queryResultCache.enabled:true}" />
+  <documentCache
+    class="${mb.documentCache.class:solr.CaffeineCache}"
+    size="${mb.documentCache.size:32768}"
+    initialSize="${mb.documentCache.initialSize:8192}"
+    autowarmCount="${mb.documentCache.autoWarmCount:4096}"
+    maxRamMB="${mb.documentCache.maxRamMB:-1}"
+    maxIdleTime="${mb.documentCache.MaxIdleTime:0}"
+    async="${mb.documentCache.async:true}"
+    enabled="${mb.documentCache.enabled:true}" />
 </query>

--- a/common/requestDispatcher.xml
+++ b/common/requestDispatcher.xml
@@ -1,3 +1,3 @@
 <requestDispatcher handleSelect="true">
-  <requestParsers enableRemoteStreaming="false" multipartUploadLimitInKB="2048" formdataUploadLimitInKB="2048" />
+  <requestParsers multipartUploadLimitInKB="2048" formdataUploadLimitInKB="2048" />
 </requestDispatcher>


### PR DESCRIPTION
# Problem

Even though it isn’t blocking SEARCH-685, the following issues matter for SolrCloud deployment:

1. Some settings under `common/` were obsolete for a long time.
2. Some settings couldn’t be quickly changed.

# Solution

1. Use `NRTCachingDirectoryFactory`
2. Use overridable parameters

# Additional change

Remove deprecated `enableRemoteStreaming` which was set to `false`, the default value anyway.

# References

* https://solr.apache.org/guide/solr/9_5/upgrade-notes/major-changes-in-solr-8.html
* https://solr.apache.org/guide/solr/9_5/upgrade-notes/major-changes-in-solr-9.html
* https://solr.apache.org/guide/solr/9_5/deployment-guide/collection-management.html#create-parameters
* https://solr.apache.org/guide/solr/9_5/deployment-guide/collection-management.html#modifycollection-parameters
* https://github.com/apache/solr/blob/c512116f6a20b3ccd0c76c0743053553da2ff53b/solr/core/src/java/org/apache/solr/servlet/SolrRequestParsers.java#L116-L117C7